### PR TITLE
Remove fields to select tags in all forms.

### DIFF
--- a/app/views/teacher/exercises/_form.html.erb
+++ b/app/views/teacher/exercises/_form.html.erb
@@ -2,7 +2,6 @@
 
   <%= f.input :title, autofocus: true %>
   <%= f.input :content, :as => :ckeditor %>
-  <%= f.association :tags, as: :mult_select, name: "Selecione as tags" %>
 
   <%= f.button :submit_materialize, cancel: teacher_lo_path(@lo) %>
 <% end %>

--- a/app/views/teacher/introductions/_form.html.erb
+++ b/app/views/teacher/introductions/_form.html.erb
@@ -2,7 +2,6 @@
 
   <%= f.input :title, autofocus: true %>
   <%= f.input :content, :as => :ckeditor %>
-  <%= f.association :tags, as: :mult_select, name: "Selecione as tags" %>
 
   <%= f.button :submit_materialize, :cancel => teacher_lo_path(@lo) %>
 <% end %>


### PR DESCRIPTION
"Remover os campos de multi select de tags dos exercicios e introduções. Não precisa remover os atributos dos modelos."